### PR TITLE
fix: type `Markable` is reduced to `Any` by mypy

### DIFF
--- a/src/_pytest/mark/structures.py
+++ b/src/_pytest/mark/structures.py
@@ -266,7 +266,7 @@ class Mark:
 # A generic parameter designating an object to which a Mark may
 # be applied -- a test function (callable) or class.
 # Note: a lambda is not allowed, but this can't be represented.
-Markable = TypeVar("Markable", bound=Union[Callable[..., object], type])
+Markable = TypeVar("Markable", bound=Callable)
 
 
 @attr.s(init=False, auto_attribs=True)


### PR DESCRIPTION
The following code: 

https://github.com/pytest-dev/pytest/blob/364bbe42fc02d435e6d94d13ad3accc7e00875fd/src/_pytest/mark/structures.py#L269

when using `reveal_type` with mypy resolves to `Any` which is not what we want, but I believe the type variable can probably be simplified to the following and still be correct:

```python
Markable = TypeVar("Markable", bound=Callable)
```

The previous definition defined the return of the callable and did accept any class. I don't believe we care about the return of the callable and classes are also callable so this should be sufficient and still correct.